### PR TITLE
Add Playwright e2e test suite for QWC2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,24 +1,5 @@
-# Compiled class file
-*.class
-
-# Log file
-*.log
-
-# BlueJ files
-*.ctxt
-
-# Mobile Tools for Java (J2ME)
-.mtj.tmp/
-
-# Package Files #
-*.jar
-*.war
-*.nar
-*.ear
-*.zip
-*.tar.gz
-*.rar
-
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
-hs_err_pid*
-replay_pid*
+node_modules/
+test-results/
+playwright-report/
+playwright/.cache/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,2 +1,73 @@
-# qwc2-e2e-tests
+# QWC2 Playwright Test Suite
 
+This repository contains automated smoke, system, and end-to-end checks for the [Kanton Solothurn QWC2 deployment](https://geo.so.ch/map/). The tests are implemented with [Playwright Test](https://playwright.dev) and cover the main map view, zoom controls, and the background layer switcher. More scenarios can be added on top of this foundation.
+
+## Prerequisites
+
+- Node.js 18 or newer (Playwright is tested with the latest LTS releases; the container uses Node 20).
+- npm (ships with Node.js) or pnpm/yarn if you prefer different package managers.
+- Internet access to reach https://geo.so.ch/ during test execution.
+- Linux desktop dependencies for browser automation. On Ubuntu/Debian you can install them once via:
+  ```bash
+  npx playwright install-deps
+  ```
+
+## Installation
+
+1. Clone this repository and install the JavaScript dependencies:
+   ```bash
+   npm install
+   ```
+2. Download the Playwright browser binaries (only needs to be done once per environment):
+   ```bash
+   npx playwright install
+   ```
+
+## Running the tests
+
+The project exposes several npm scripts:
+
+- Run the full suite headlessly:
+  ```bash
+  npm test
+  ```
+- Run headfully (headed mode) to observe the browser:
+  ```bash
+  npm run test:headed
+  ```
+- Debug individual tests with Playwright Inspector:
+  ```bash
+  npm run test:debug
+  ```
+- Launch the interactive Playwright UI test runner:
+  ```bash
+  npm run test:ui
+  ```
+
+All test commands automatically dismiss the news popup shown on first load and ignore the certificate warning presented by the production instance.
+
+## Playwright MCP server
+
+The repository also includes Microsoft Playwright's [Model Context Protocol](https://github.com/modelcontextprotocol) server. After installing dependencies you can expose the Playwright automation tools to MCP-compliant clients with:
+```bash
+npm run mcp
+```
+This starts the MCP server on the default port and allows tools such as Claude Code to drive the same Playwright workflows defined in this suite.
+
+## Project structure
+
+```
+.
+├── playwright.config.ts        # Global Playwright configuration
+├── tests/                      # Test specs and helpers
+│   ├── helpers.ts              # Shared navigation utilities (dismiss popups, open homepage)
+│   ├── smoke.spec.ts           # Basic availability and UI assertions
+│   └── map-controls.spec.ts    # Zoom control and background layer switcher coverage
+└── README.md                   # This guide
+```
+
+## Next steps
+
+- Extend the functional coverage (e.g., search, layer catalog, measurement tools).
+- Integrate the suite with your CI system by exporting standard Playwright reports (`playwright-report/`).
+- Add environment variables for testing against staging or development deployments if needed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,129 @@
+{
+  "name": "qwc2-e2e-tests",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "qwc2-e2e-tests",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@playwright/mcp": "^0.0.39",
+        "@playwright/test": "^1.55.1"
+      }
+    },
+    "node_modules/@playwright/mcp": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@playwright/mcp/-/mcp-0.0.39.tgz",
+      "integrity": "sha512-InIFtJSDg+TtoEeFUCGi3bE49In725N6v2B8GEFbm373Mbt5Mv2GO2rq/XdFiVaF4+EkpfXw7zd5ACUMLJJxmA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.56.0-alpha-1758292576000",
+        "playwright-core": "1.56.0-alpha-1758292576000"
+      },
+      "bin": {
+        "mcp-server-playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.1.tgz",
+      "integrity": "sha512-IVAh/nOJaw6W9g+RJVlIQJ6gSiER+ae6mKQ5CX1bERzQgbC1VSeBlwdvczT7pxb0GWiyrxH4TGKbMfDb4Sq/ig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@playwright/test/node_modules/playwright": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.1.tgz",
+      "integrity": "sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/@playwright/test/node_modules/playwright-core": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.1.tgz",
+      "integrity": "sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.56.0-alpha-1758292576000",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.0-alpha-1758292576000.tgz",
+      "integrity": "sha512-XRTRlArx9KgiGsboXUpJR7ZDazUPfO51t1nrQ+w883e02/IDNxcqPpQXJcFAy4nFqG925r//VR9AyseVfw1AWg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.56.0-alpha-1758292576000"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.56.0-alpha-1758292576000",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.0-alpha-1758292576000.tgz",
+      "integrity": "sha512-qXLOCI9RhulhdvNjFglvgoyUw3N49putP8iU0uhoZ+mE3lEXAJNy/v1znCRvhjwvfsGsabO9+Xe4sfvu2GFGCw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "qwc2-e2e-tests",
+  "version": "1.0.0",
+  "description": "Playwright-based smoke, system, and end-to-end tests for the Kanton Solothurn QWC2 deployment.",
+  "main": "index.js",
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "test:debug": "PWDEBUG=1 playwright test --headed",
+    "test:ui": "playwright test --ui",
+    "mcp": "playwright mcp"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "@playwright/mcp": "^0.0.39",
+    "@playwright/test": "^1.55.1"
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  timeout: 60 * 1000,
+  expect: {
+    timeout: 10 * 1000,
+  },
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 2 : undefined,
+  reporter: [['list'], ['html', { open: 'never' }]],
+  use: {
+    baseURL: 'https://geo.so.ch/map/',
+    headless: true,
+    viewport: { width: 1280, height: 720 },
+    actionTimeout: 15 * 1000,
+    navigationTimeout: 30 * 1000,
+    ignoreHTTPSErrors: true,
+    trace: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+  ],
+  outputDir: 'test-results',
+});

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,0 +1,33 @@
+import { Locator, Page } from '@playwright/test';
+
+export async function dismissNewsPopup(page: Page): Promise<void> {
+  const closeButton: Locator = page.locator(
+    'button:has-text("Schliessen"), button:has-text("Schließen"), button:has-text("Close")',
+  );
+  if (await closeButton.count()) {
+    await closeButton.first().click();
+    await page.waitForTimeout(500);
+  }
+}
+
+export async function openHome(page: Page): Promise<void> {
+  await page.goto('/');
+  await page.waitForLoadState('domcontentloaded');
+
+  if (!/geo\.so\.ch\/map/i.test(page.url())) {
+    const mapLink = page.locator('a[href*="geo.so.ch/map" i]');
+    if (await mapLink.count()) {
+      const targetUrl = await mapLink.first().getAttribute('href');
+      if (targetUrl) {
+        await page.goto(targetUrl);
+      }
+    } else {
+      await page.goto('https://geo.so.ch/map/');
+    }
+  }
+
+  await page.waitForURL(/geo\.so\.ch\/map/i, { timeout: 15000 });
+  await page.waitForLoadState('domcontentloaded');
+  await page.locator('#map').waitFor({ state: 'visible', timeout: 30000 });
+  await dismissNewsPopup(page);
+}

--- a/tests/map-controls.spec.ts
+++ b/tests/map-controls.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+import { openHome } from './helpers';
+
+test.describe('Map control interactions', () => {
+  test.beforeEach(async ({ page }) => {
+    await openHome(page);
+  });
+
+  test('zoom controls update the visible scale', async ({ page }) => {
+    const zoomInButton = page.locator('button[title="Zoom in"]');
+    await expect(zoomInButton).toBeVisible({ timeout: 60000 });
+
+    const scaleLocator = page.locator('.ol-scale-line-inner');
+    await expect(scaleLocator).toBeVisible({ timeout: 60000 });
+    const initialScale = (await scaleLocator.innerText()).trim();
+
+    await zoomInButton.click();
+    await expect(scaleLocator).not.toHaveText(initialScale, { timeout: 10000 });
+
+    const zoomedScale = (await scaleLocator.innerText()).trim();
+    expect(zoomedScale).not.toEqual(initialScale);
+
+    await page.locator('button[title="Zoom out"]').click();
+    await expect(scaleLocator).toHaveText(initialScale, { timeout: 10000 });
+  });
+
+  test('background layer switcher lists available basemaps', async ({ page }) => {
+    const backgroundButton = page.locator('button[title="Switch background"]');
+    await expect(backgroundButton).toBeVisible({ timeout: 60000 });
+    await backgroundButton.click();
+
+    const layerItems = page.locator('.background-switcher-item');
+    await expect(layerItems.first()).toBeVisible();
+    expect(await layerItems.count()).toBeGreaterThan(0);
+
+    const activeLayer = page.locator('.background-switcher-item-active');
+    await expect(activeLayer).toHaveCount(1);
+
+    const alternativeLayer = layerItems.filter({ hasText: 'Luftbild' });
+    if (await alternativeLayer.count()) {
+      await alternativeLayer.first().click();
+      await expect(page.locator('.background-switcher-item-active')).toContainText('Luftbild');
+    }
+  });
+});

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+import { openHome } from './helpers';
+
+test.describe('QWC2 smoke tests', () => {
+  test('loads the main map view with core UI elements', async ({ page }) => {
+    await openHome(page);
+
+    await expect(page).toHaveTitle(/Kanton Solothurn/i);
+
+    const mapCanvas = page.locator('#map canvas');
+    await expect(mapCanvas).toHaveCount(1, { timeout: 60000 });
+    await expect(mapCanvas.first()).toBeVisible({ timeout: 60000 });
+
+    const searchInput = page.locator('input[placeholder="Search place or add map..."]');
+    await expect(searchInput).toBeVisible({ timeout: 60000 });
+    await expect(searchInput).toHaveAttribute('type', 'text');
+
+    const scaleBar = page.locator('.ol-scale-line-inner');
+    await expect(scaleBar).toBeVisible({ timeout: 60000 });
+    await expect(scaleBar).toHaveText(/\d+\s*(m|km)/);
+  });
+});


### PR DESCRIPTION
## Summary
- add Playwright configuration, dependencies, and npm scripts for running tests across Chromium, Firefox, and WebKit
- implement helpers plus smoke and map control test suites that navigate to the public QWC2 map, close popups, and exercise core UI controls
- document setup steps, test commands, and MCP server usage in the README

## Testing
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_68d3a56b955483289ff9758d105232e7